### PR TITLE
Improve precommit script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,8 @@
+#!/usr/bin/env sh
+
 # Prevent committing dist/ai-bands.json
-if git diff --cached --name-only | grep -q "dist/ai-bands.json"; then
-  echo "❌ dist/ai-bands.json is auto-generated. Please do not commit it with your PR."
-  exit 1
+if git diff --cached --name-only | node -e "process.stdin.on('data', d => process.exit(d.toString().split('\n').some(f => f === 'dist/ai-bands.json') ? 0 : 1))"; then
+  echo "dist/ai-bands.json is auto-generated. Please do not commit it with your PR."
+  git restore --staged -- dist/ai-bands.json
+  echo "dist/ai-bands.json has been unstaged from this commit."
 fi


### PR DESCRIPTION
- Cross platform support (windows now works)
- Instead of exiting, it upstages the file (not everyone new to git knows how to do this) and lets the commit go forwards without changing the dist file.

Note that this script running requires them to have node and run `npm install` so that will need to be added to contrib guidelines later, maybe after my add artist script is added.