### PR TITLE
Add social links to PR comments for easier reviewing

### DIFF
--- a/.github/scripts/create-artist-add-issue.js
+++ b/.github/scripts/create-artist-add-issue.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { resolveHandle } from './youtube.js';
 // import { createSpotifyClient } from './spotify.js';
+import { generateQueryParams, generateSocialLinks, formatIssueBody } from './issue-utils.js';
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
@@ -41,25 +42,12 @@ if (orderedData.youtube && orderedData.youtube.startsWith('@')) {
 }
 
 // Create link to souloverai.com submission form with prefilled data
-const params = Object.keys(orderedData)
-  .map(key => {
-    let value = orderedData[key];
-    if (Array.isArray(value)) {
-      if (value.length === 0) return null;
-      value = value.join(',');
-    } else if (value === null || value === undefined) {
-      return null;
-    }
-    const encodedValue = encodeURIComponent(value)
-      .replace(/\(/g, '%28') // left parenthesis
-      .replace(/\)/g, '%29'); // right parenthesis
-    return `${key}=${encodedValue}`;
-  })
-  .filter(Boolean)
-  .join('&');
-
-const link = `[Make changes](https://souloverai.com/add?${params})`;
-const issueBody = `\`\`\`json\n${JSON.stringify(orderedData, null, 2)}\n\`\`\`\n\n${link}`;
+const params = generateQueryParams(orderedData);
+const issueBody = formatIssueBody(
+  orderedData,
+  generateSocialLinks(orderedData),
+  `https://souloverai.com/add?${params}`,
+);
 
 // If an issue with the same artist name exists, add a comment instead of creating a new issue
 (async () => {

--- a/.github/scripts/issue-utils.js
+++ b/.github/scripts/issue-utils.js
@@ -1,0 +1,41 @@
+export function generateQueryParams(data, excludeKeys = []) {
+  return Object.keys(data)
+    .filter(key => !excludeKeys.includes(key))
+    .map(key => {
+      let value = data[key];
+      if (Array.isArray(value)) {
+        if (value.length === 0) return null;
+        value = value.join(',');
+      } else if (value === null || value === undefined) {
+        return null;
+      }
+      const encodedValue = encodeURIComponent(value)
+        .replace(/\(/g, '%28') // left parenthesis
+        .replace(/\)/g, '%29'); // right parenthesis
+      return `${key}=${encodedValue}`;
+    })
+    .filter(Boolean)
+    .join('&');
+}
+
+export function generateSocialLinks(data) {
+  return [
+    data.spotify?.length ? `* [Spotify](https://open.spotify.com/artist/${data.spotify})` : null,
+    data.apple?.length ? `* [Apple Music](https://music.apple.com/us/artist/${data.apple})` : null,
+    data.amazon?.length ? `* [Amazon Music](https://music.amazon.com/artists/${data.amazon})` : null,
+    data.youtube?.length ? `* [YouTube](https://www.youtube.com/channel/${data.youtube})` : null,
+    data.tiktok?.length ? `* [TikTok](https://www.tiktok.com/${data.tiktok})` : null,
+    data.instagram?.length ? `* [Instagram](https://www.instagram.com/${data.instagram})` : null,
+  ].filter(Boolean);
+}
+
+export function formatIssueBody(contents, links, editUrl) {
+  const bodyContents = "```json\n" + JSON.stringify(contents, null, 2) + "\n```";
+  return [
+    bodyContents,
+    links.length ? links.join('\n') : null,
+    `[Make changes](${editUrl})`,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}


### PR DESCRIPTION
Both `add-issue` and `update-issue`.

This introduces a few functions in `issue-utils.js` to avoid copy/pasted code.

GitHub automatically adds `rel=noreferrer` etc. to external links, so this does not pose privacy leak issues.

Unfortunately I am not able to test this in a real context, but calling `node` v20 on a dummy payload works just fine.