### PR TITLE
Disable scheduled build for dist artists

### DIFF
--- a/.github/workflows/build-dist-artists.yml
+++ b/.github/workflows/build-dist-artists.yml
@@ -1,8 +1,8 @@
 name: Build dist
 
 on:
-  schedule:
-    - cron: '0 */2 * * *'
+#  schedule:
+#    - cron: '0 */2 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Comment out the scheduled cron job for the build workflow.